### PR TITLE
Add script to check image URLs

### DIFF
--- a/recipes-scripts/check-images.sh
+++ b/recipes-scripts/check-images.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+while getopts f: flag
+do
+    case "${flag}" in
+        f) FILE=${OPTARG};;
+        h) printf "
+Ping each image for the input (an ndjson file containing a single recipe per line), giving a status code.
+
+Usage: ./check-images.sh -f FILE
+"
+        exit 0;;
+        *) echo "Unrecognised argument $OPTARG"
+    esac
+done
+
+echo "Reading $FILE."
+
+function check_image() {
+  curl -s -o /dev/null -w "%{http_code}\n" "$1"
+}
+
+IMAGE_VARS=$(jq -r -c "{\"featuredImage\": .featuredImage.url, \"previewImage\": .previewImage.url, \"id\": .id}" "$FILE")
+
+while read -r IMAGE_VAR; do
+  FEATURED_IMAGE=$(jq -r .featuredImage <<< "$IMAGE_VAR")
+  PREVIEW_IMAGE=$(jq -r .previewImage <<< "$IMAGE_VAR")
+  ID=$(jq -r .id <<< "$IMAGE_VAR")
+
+  echo "Recipe $ID"
+  echo "Featured image $FEATURED_IMAGE: $(check_image "$FEATURED_IMAGE")"
+  echo "Preview image $PREVIEW_IMAGE: $(check_image "$PREVIEW_IMAGE")"
+done <<< "$IMAGE_VARS"
+


### PR DESCRIPTION
## What does this change?

Adds a script to check our image URLs are giving the right status code.

```
./check-images.sh recipes.prod.ndjson

Reading recipes.prod.ndjson.
Recipe c343e2d571984e41bde5a121b4a3efa4
Featured image https://i.guim.co.uk/img/media/5aae153b023ab4d1d27dd9fabc1d7e8615afdbce/0_0_3621_4269/master/3621.jpg?width=1600&dpr=1&s=none: 200
Preview image https://i.guim.co.uk/img/media/5aae153b023ab4d1d27dd9fabc1d7e8615afdbce/0_0_3621_4269/master/3621.jpg?width=1600&dpr=1&s=none: 200
Recipe 2ded65e369b24036a0d55bff659287db
Featured image https://i.guim.co.uk/img/media/66137b378596a78db4409b3eedc6cbd5516dfe29/0_0_3519_4150/master/1696.jpg?width=1600&dpr=1&s=none: 200
Preview image https://i.guim.co.uk/img/media/66137b378596a78db4409b3eedc6cbd5516dfe29/0_0_3519_4150/master/1696.jpg?width=1600&dpr=1&s=none: 200
Recipe a439ce94284a47afa5b188216bbb300e

... etc
```

## How to test

Give it a try!

Used successfully to test https://github.com/guardian/recipes-backend/pull/32.